### PR TITLE
Change include to an auth_redirect

### DIFF
--- a/sc-dashboard.php
+++ b/sc-dashboard.php
@@ -282,7 +282,7 @@ class StudyChurch {
 			}
 		}
 
-		include( get_home_url() . '/join' );
+		auth_redirect();
 		exit();
 	}
 


### PR DESCRIPTION
I believe the full URL include was causing the issue since most servers (that I know of) don't allow you to include a PHP file with a full URL and they want the path instead. This removes the include and uses the auth_redirect() function in place of it and seems to work on my local install. Would like to make sure this works well on the staging site.