### PR TITLE
Delete a study chapter

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="Eslint" enabled="true" level="ERROR" enabled_by_default="true" />
-  </profile>
-</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/app/src/pages/Dashboard/Groups/Views/Assignments.vue
+++ b/app/src/pages/Dashboard/Groups/Views/Assignments.vue
@@ -52,7 +52,7 @@
 			&nbsp;
 			<h6>Due Date: {{data.date}}</h6>
 			<p v-for="lesson in data.lessons">
-				<router-link :to="'/groups/' + $route.params.slug + $root.cleanLink(lesson.link)">
+				<router-link v-if="lesson.link != false" :to="'/groups/' + $route.params.slug + $root.cleanLink(lesson.link)">
 					<i class="now-ui-icons design_bullet-list-67"></i>&nbsp;
 					<span v-html="lesson.title"></span></router-link>
 			</p>

--- a/app/src/pages/Dashboard/Studio/Views/StudyEdit.vue
+++ b/app/src/pages/Dashboard/Studio/Views/StudyEdit.vue
@@ -70,6 +70,9 @@
 					<draggable v-model="navigation" :options="{draggable: '.item', handle : '.drag-item'}" @end="saveNavigation">
 						<div v-for="item in navigation" :key="item.id" class="item">
 							<p>
+								<a @click="deleteChapter( item )" class="remove float-right" href="#">
+									<font-awesome-icon icon="times"></font-awesome-icon>
+								</a>
 								<a class="float-right drag-item" href="#">
 									<font-awesome-icon icon="arrows-alt"></font-awesome-icon>
 								</a>
@@ -274,6 +277,13 @@
             this.newChapter = '';
           })
       },
+		deleteChapter( item ) {
+          console.log( 'Deleting Chapter: ' + item.id );
+
+          this.$store.dispatch( 'study/deleteStudyChapter', item.id ).then( response => {
+              console.log( 'Delete Response', response );
+		  } );
+		},
       saveStudy() {
         this.loading = true;
         this.$store

--- a/app/src/pages/Dashboard/Studio/Views/StudyEdit.vue
+++ b/app/src/pages/Dashboard/Studio/Views/StudyEdit.vue
@@ -131,6 +131,7 @@
   import { Select, Option, RadioGroup, RadioButton, DatePicker, Input } from 'element-ui';
   import { mapState, mapGetters } from 'vuex';
   import AvatarCropper from "vue-avatar-cropper";
+  import swal from 'sweetalert2';
 
   export default {
     components: {
@@ -278,11 +279,30 @@
           })
       },
 		deleteChapter( item ) {
-          console.log( 'Deleting Chapter: ' + item.id );
 
-          this.$store.dispatch( 'study/deleteStudyChapter', item.id ).then( response => {
-              console.log( 'Delete Response', response );
-		  } );
+            this.loadingChapters = true;
+            swal( {
+                title: 'Are you sure you want to remove this?',
+                text: 'You won\'t be able to revert this.',
+                type: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Remove',
+                showLoaderOnConfirm: true,
+                preConfirm: () => {
+                this.$store.dispatch( 'study/deleteStudyChapter', item.id ).then( response => {
+						this.$store
+							.dispatch('study/updateNavigation', {studyID: this.studyData.id })
+							.then(response => {
+							this.navigation = response;
+							this.loadingChapters = false;
+						});
+				});
+				}
+       		 } ).then( (value) => {
+       		     if ( value.dismiss && value.dismiss == 'cancel' ) {
+                	this.loadingChapters = false;
+            	}
+			});
 		},
       saveStudy() {
         this.loading = true;

--- a/app/src/services/StudyService.js
+++ b/app/src/services/StudyService.js
@@ -48,5 +48,8 @@ export default {
         'Content-Type': 'multipart/form-data',
       }
     });
-  }
+  },
+    deleteStudyChapter( id ) {
+      return apiClient.delete( base + id + '/navigation', id );
+    }
 }

--- a/app/src/store/modules/study.js
+++ b/app/src/store/modules/study.js
@@ -168,6 +168,11 @@ export const actions = {
         return response.data;
       });
   },
+    deleteStudyChapter( {commit}, id ) {
+      return StudyService.deleteStudyChapter( id ).then( response => {
+        return response.data;
+      } );
+    },
   updateStudyChapter({commit, getters, state}, {chapterID, data}) {
     return StudyService.updateStudyChapter(chapterID, data)
       .then(response => {

--- a/app/src/store/modules/study.js
+++ b/app/src/store/modules/study.js
@@ -169,9 +169,7 @@ export const actions = {
       });
   },
     deleteStudyChapter( {commit}, id ) {
-      return StudyService.deleteStudyChapter( id ).then( response => {
-        return response.data;
-      } );
+      return StudyService.deleteStudyChapter( id ).then();
     },
   updateStudyChapter({commit, getters, state}, {chapterID, data}) {
     return StudyService.updateStudyChapter(chapterID, data)

--- a/inc/API/Studies.php
+++ b/inc/API/Studies.php
@@ -93,6 +93,11 @@ class Studies extends WP_REST_Posts_Controller {
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( false ),
 			),
+            array(
+                'methods'             => WP_REST_Server::DELETABLE,
+                'callback'            => array( $this, 'remove_chapter' ),
+                'permission_callback' => array( $this, 'update_item_permissions_check' ),
+            ),
 		) );
 
 		register_rest_route( $this->namespace, $this->base . '/(?P<study_id>[a-zA-Z0-9-]+)/chapters', array(
@@ -572,6 +577,25 @@ class Studies extends WP_REST_Posts_Controller {
 
 		return $this->get_navigation( $request );
 	}
+
+	public function remove_chapter( $request ) {
+
+	    if ( ! isset( $request['id'] ) ) {
+	        return new WP_Error( 'invalid data', 'Please provide an ID' );
+        }
+
+        $p = wp_delete_post( absint( $request['id'] ), true );
+
+	    if ( false === $p ) {
+	        return array(
+	            'message' => 'Error removing item, please try again or contact support.',
+            );
+        }
+
+        return array(
+            'message' => 'Item removed!',
+        );
+    }
 
 	public function update_item_thumbnail( $request ) {
 		require_once( ABSPATH . 'wp-admin/includes/image.php' );


### PR DESCRIPTION
@tannerm Alright I think this is ready. It will add a little X next to the move handle. That will allow the user to delete the chapter and it uses the sweet alert modal to confirm before deleting. 

I decided to check (and my Slack question I had) the TODOs if a chapter was deleted and it just showe blank links because it was returning `false`. My last commit is a temp fix to this, it's just a `v-if` check for the link status and if it's false it doesn't output it. Should be good for now probably, but if I need to change that then let me know.