### PR TITLE
Fix video sizing style so it's not youtube specific

### DIFF
--- a/app/src/assets/sass/studychurch.scss
+++ b/app/src/assets/sass/studychurch.scss
@@ -1,4 +1,4 @@
 
-.youtube-player {
+.fr-video iframe {
   max-width: 100%;
 }


### PR DESCRIPTION
This one should work better @tannerm. I test with both YouTube and Vimeo and they both get wrapped in the container with the `.fr-video` class.